### PR TITLE
Adding optional support for entity framework migrations.

### DIFF
--- a/SqliteWasmHelper/Extensions.cs
+++ b/SqliteWasmHelper/Extensions.cs
@@ -21,16 +21,19 @@ namespace SqliteWasmHelper
         /// <param name="optionsAction">An action used to configure <see cref="DbContextOptions{TContext}"/>.
         /// </param>
         /// <param name="lifetime">Lifetime of the service.</param>
+        /// <param name="migration">See <see cref="Migration"/>.</param>
         /// <returns>The service implementation.</returns>
         public static IServiceCollection AddSqliteWasmDbContextFactory<TContext>(
             this IServiceCollection serviceCollection,
             Action<DbContextOptionsBuilder>? optionsAction = null,
-            ServiceLifetime lifetime = ServiceLifetime.Singleton)
+            ServiceLifetime lifetime = ServiceLifetime.Singleton,
+            Migration? migration = null)
             where TContext : DbContext
         => AddSqliteWasmDbContextFactory<TContext>(
             serviceCollection,
             optionsAction == null ? null : (_, oa) => optionsAction(oa),
-            lifetime);
+            lifetime,
+            migration);
 
         /// <summary>
         /// Add helper factory.
@@ -40,11 +43,13 @@ namespace SqliteWasmHelper
         /// <param name="optionsAction">An action used to configure <see cref="DbContextOptions{TContext}"/>.
         /// </param>
         /// <param name="lifetime">Lifetime of the service.</param>
+        /// <param name="migration">See <see cref="Migration"/>.</param>
         /// <returns>The service implementation.</returns>
         public static IServiceCollection AddSqliteWasmDbContextFactory<TContext>(
        this IServiceCollection serviceCollection,
        Action<IServiceProvider, DbContextOptionsBuilder>? optionsAction,
-       ServiceLifetime lifetime = ServiceLifetime.Singleton)
+       ServiceLifetime lifetime = ServiceLifetime.Singleton,
+       Migration? migration = null)
        where TContext : DbContext
         {
             serviceCollection.TryAdd(
@@ -67,6 +72,8 @@ namespace SqliteWasmHelper
 
             serviceCollection.AddDbContextFactory<TContext>(
                 optionsAction ?? ((s, p) => { }), lifetime);
+
+            serviceCollection.AddSingleton<IMigration>(migration ?? new(false));
 
             return serviceCollection;
         }

--- a/SqliteWasmHelper/IMigration.cs
+++ b/SqliteWasmHelper/IMigration.cs
@@ -1,0 +1,18 @@
+﻿// <copyright file="IMigration.cs" company="Jeremy Likness">
+// Copyright (c) Jeremy Likness. All rights reserved.
+// </copyright>
+
+namespace SqliteWasmHelper
+{
+    /// <summary>
+    /// Determines whether to use the migration strategy or ensure created.
+    /// </summary>
+    public interface IMigration
+    {
+        /// <summary>
+        /// Reads the prefered entity framework database creation strategy.
+        /// </summary>
+        /// <returns>True to use migration. False to use ensure created.</returns>
+        bool UseMigration();
+    }
+}

--- a/SqliteWasmHelper/Migration.cs
+++ b/SqliteWasmHelper/Migration.cs
@@ -1,0 +1,29 @@
+﻿// <copyright file="Migration.cs" company="Jeremy Likness">
+// Copyright (c) Jeremy Likness. All rights reserved.
+// </copyright>
+
+namespace SqliteWasmHelper
+{
+    /// <summary>
+    /// Class for determining migration method.
+    /// </summary>
+    public class Migration : IMigration
+    {
+        private readonly bool useMigration;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Migration"/> class.
+        /// </summary>
+        /// <param name="useMigration">True for using entity framework migrations. False for ensure created.</param>
+        public Migration(bool useMigration = false)
+        {
+            this.useMigration = useMigration;
+        }
+
+        /// <summary>
+        /// True for using entity framework migrations. False for ensure created.
+        /// </summary>
+        /// <returns>Boolean true for using entity framework migrations. False for ensure created.</returns>
+        public bool UseMigration() => useMigration;
+    }
+}

--- a/SqliteWasmTests/FactoryTests.cs
+++ b/SqliteWasmTests/FactoryTests.cs
@@ -16,6 +16,7 @@ namespace SqliteWasmTests
         private readonly MockSwap swap;
         private readonly string filename;
         private readonly string altFilename;
+        private readonly MockMigration mockMigration;
 
         private ISqliteWasmDbContextFactory<TestContext> CreateFactory(
             string? ds = null)
@@ -32,7 +33,8 @@ namespace SqliteWasmTests
             var factory = new SqliteWasmDbContextFactory<TestContext>(
                 dbContextFactory,
                 mockBrowserCache,
-                swap);
+                swap,
+                mockMigration);
             return factory;
         }
 
@@ -42,6 +44,7 @@ namespace SqliteWasmTests
             filename = Guid.NewGuid().ToString();
             altFilename = Guid.NewGuid().ToString();
             swap = new MockSwap();
+            mockMigration = new MockMigration();
         }
 
         [Fact]

--- a/SqliteWasmTests/TestHelpers/MockMigration.cs
+++ b/SqliteWasmTests/TestHelpers/MockMigration.cs
@@ -1,0 +1,9 @@
+﻿using SqliteWasmHelper;
+
+namespace SqliteWasmTests.TestHelpers
+{
+    public class MockMigration : IMigration
+    {
+        public bool UseMigration() => false;
+    }
+}


### PR DESCRIPTION
Adds the ability to specify the migration strategy. An optional object "Migration" can be instantiated with a value of true and passed in when adding the context factory to allow entity framework migrations to be used.

Closes #11 
Closes #23 