### PR TITLE
Adding the ability to manually restore a database from a file.

### DIFF
--- a/SqliteWasmHelper/BrowserCache.cs
+++ b/SqliteWasmHelper/BrowserCache.cs
@@ -49,6 +49,18 @@ namespace SqliteWasmHelper
         }
 
         /// <summary>
+        /// Calls the code to restore the database from a given ArrayBuffer.
+        /// </summary>
+        /// <param name="arrayBuffer">The ArrayBuffer containing the database file.</param>
+        /// <param name="filename">The name of the file to process.</param>
+        /// <returns>0 if successful, -1 otherwise.</returns>
+        public async Task<int> ManualRestore(byte[] arrayBuffer, string filename)
+        {
+            var module = await moduleTask.Value;
+            return await module.InvokeAsync<int>("manualRestore", arrayBuffer, filename);
+        }
+
+        /// <summary>
         /// Creates an anchor tag to download the database and injects it into the parent.
         /// </summary>
         /// <param name="parent">The host for the tag.</param>

--- a/SqliteWasmHelper/IBrowserCache.cs
+++ b/SqliteWasmHelper/IBrowserCache.cs
@@ -19,6 +19,14 @@ namespace SqliteWasmHelper
         Task<int> SyncDbWithCacheAsync(string filename);
 
         /// <summary>
+        /// Calls the code to restore the database from a given ArrayBuffer.
+        /// </summary>
+        /// <param name="arrayBuffer">The ArrayBuffer containing the database file.</param>
+        /// <param name="filename">The name of the file to process.</param>
+        /// <returns>0 if successful, -1 otherwise.</returns>
+        Task<int> ManualRestore(byte[] arrayBuffer, string filename);
+
+        /// <summary>
         /// Creates an anchor tag to download the database and injects it into the parent.
         /// </summary>
         /// <param name="parent">The host for the tag.</param>

--- a/SqliteWasmHelper/ISqliteWasmDbContextFactory.cs
+++ b/SqliteWasmHelper/ISqliteWasmDbContextFactory.cs
@@ -18,5 +18,12 @@ namespace SqliteWasmHelper
         /// </summary>
         /// <returns>The new context.</returns>
         Task<TContext> CreateDbContextAsync();
+
+        /// <summary>
+        /// Calls the code to restore the database from a given ArrayBuffer.
+        /// </summary>
+        /// <param name="arrayBuffer">The ArrayBuffer containing the database file.</param>
+        /// <returns>0 if successful, -1 otherwise.</returns>
+        Task<int> ManualRestore(byte[] arrayBuffer);
     }
 }

--- a/SqliteWasmHelper/SqliteWasmDbContextFactory.cs
+++ b/SqliteWasmHelper/SqliteWasmDbContextFactory.cs
@@ -99,6 +99,23 @@ namespace SqliteWasmHelper
             return ctx;
         }
 
+        /// <summary>
+        /// Calls the code to restore the database from a given ArrayBuffer.
+        /// </summary>
+        /// <param name="arrayBuffer">The ArrayBuffer containing the database file.</param>
+        /// <returns>0 if successful, -1 otherwise.</returns>
+        public async Task<int> ManualRestore(byte[] arrayBuffer)
+        {
+            var filename = $"{GetFilename()}_bak";
+            int restoreStatus = await cache.ManualRestore(arrayBuffer, filename);
+            if (restoreStatus == 0)
+            {
+                DoSwap(filename, FileNames[typeof(TContext)]);
+            }
+
+            return restoreStatus;
+        }
+
         private void DoSwap(string source, string target) =>
             swap.DoSwap(source, target);
 

--- a/SqliteWasmHelper/wwwroot/browserCache.js
+++ b/SqliteWasmHelper/wwwroot/browserCache.js
@@ -86,3 +86,40 @@ export async function generateDownloadLink(parent, file) {
 
     return false;
 }
+
+export async function manualRestore(arrayBuffer, file) {
+    window.sqlitedb = window.sqlitedb || {
+        init: false,
+        cache: await caches.open('SqliteWasmHelper')
+    };
+
+    const db = window.sqlitedb;
+
+    const backupPath = `/${file}`;
+    const cachePath = `/data/cache/${file.substring(0, file.indexOf('_bak'))}`;
+
+    if (arrayBuffer) {
+        console.log(`Restoring ${arrayBuffer.byteLength} bytes.`);
+        window.Module.FS.writeFile(backupPath, new Uint8Array(arrayBuffer));
+
+        const blob = new Blob([arrayBuffer], {
+            type: 'application/octet-stream',
+            ok: true,
+            status: 200
+        });
+
+        const headers = new Headers({
+            'content-length': blob.size
+        });
+
+        const response = new Response(blob, {
+            headers
+        });
+
+        await db.cache.put(cachePath, response);
+
+        return 0;
+    }
+
+    return -1;
+}


### PR DESCRIPTION
Example of usage where `file` is an IBrowserFile:
```C#
    async Task RestoreDatabase()
    {
        Stream stream = file!.OpenReadStream();
        byte[] backupFile = new byte[file.Size];
        await stream.ReadAsync(backupFile);
        await ExampleDbContextFactory.ManualRestore(backupFile);
    }
```

My use case is primarily for debugging purposes, but it seemed useful enough to just add for use by all.

The only concern I have in terms of merging is the amount of duplicate code in browserCache.js, but I did not want to refactor any existing code.

Merging could potentially close #21 and #16 since you could grab the file and then restore the database.