### PR TITLE
Fixing incompatibility with .NET 9.

### DIFF
--- a/BlazorWasmExample/BlazorWasmExample.csproj
+++ b/BlazorWasmExample/BlazorWasmExample.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
 	<WasmBuildNative>true</WasmBuildNative>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.5" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.1" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BlazorWasmExample/Shared/NavMenu.razor
+++ b/BlazorWasmExample/Shared/NavMenu.razor
@@ -14,16 +14,6 @@
                 <span class="oi oi-home" aria-hidden="true"></span> Home
             </NavLink>
         </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="counter">
-                <span class="oi oi-plus" aria-hidden="true"></span> Counter
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="fetchdata">
-                <span class="oi oi-list-rich" aria-hidden="true"></span> Fetch data
-            </NavLink>
-        </div>
     </nav>
 </div>
 

--- a/SqliteWasmHelper/SqliteWasmDbContextFactory.cs
+++ b/SqliteWasmHelper/SqliteWasmDbContextFactory.cs
@@ -21,7 +21,6 @@ namespace SqliteWasmHelper
         private readonly ISqliteSwap swap;
         private readonly bool useMigrations;
         private Task<int>? startupTask = null;
-        private int lastStatus = -2;
         private bool init = false;
 
         /// <summary>
@@ -162,7 +161,7 @@ namespace SqliteWasmHelper
         {
             if (startupTask != null)
             {
-                lastStatus = await startupTask;
+                await startupTask;
                 startupTask?.Dispose();
                 startupTask = null;
             }
@@ -178,14 +177,14 @@ namespace SqliteWasmHelper
                 var backupName =
                     $"{SqliteWasmDbContextFactory<TContext>.BackupFile}-{Guid.NewGuid().ToString().Split('-')[0]}";
                 DoSwap(SqliteWasmDbContextFactory<TContext>.Filename, backupName);
-                lastStatus = await cache.SyncDbWithCacheAsync(backupName);
+                await cache.SyncDbWithCacheAsync(backupName);
             }
         }
 
         private async Task<int> RestoreAsync()
         {
             var filename = $"{GetFilename()}_bak";
-            lastStatus = await cache.SyncDbWithCacheAsync(filename);
+            var lastStatus = await cache.SyncDbWithCacheAsync(filename);
             if (lastStatus == 0)
             {
                 DoSwap(filename, FileNames[typeof(TContext)]);

--- a/SqliteWasmHelper/SqliteWasmHelper.csproj
+++ b/SqliteWasmHelper/SqliteWasmHelper.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Title>SQLite WASM Helper for EF Core</Title>
 	  <Description>Helper library for using SQLite with EF Core in the browser on Blazor WebAssembly. Provides
 	  the hooks to store the database in the browser application cache.</Description>   
@@ -44,13 +44,13 @@
 	</PropertyGroup>
 	
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="7.0.5" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.119">
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="9.0.1" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.4" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.10" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/SqliteWasmHelper/wwwroot/browserCache.js
+++ b/SqliteWasmHelper/wwwroot/browserCache.js
@@ -16,20 +16,20 @@ export async function synchronizeDbWithCache(file) {
 
         const resp = await db.cache.match(cachePath);
 
-        if (resp && resp.ok) {
+        if (resp?.ok) {
 
             const res = await resp.arrayBuffer();
 
             if (res) {
                 console.log(`Restoring ${res.byteLength} bytes.`);
-                window.Module.FS.writeFile(backupPath, new Uint8Array(res));
+                Blazor.runtime.Module.FS.writeFile(backupPath, new Uint8Array(res));
                 return 0;
             }
         }
         return -1;
     }
 
-    if (window.Module.FS.analyzePath(backupPath).exists) {
+    if (Blazor.runtime.Module.FS.analyzePath(backupPath).exists) {
 
         const waitFlush = new Promise((done, _) => {
             setTimeout(done, 10);
@@ -37,7 +37,7 @@ export async function synchronizeDbWithCache(file) {
 
         await waitFlush;
 
-        const data = window.Module.FS.readFile(backupPath);
+        const data = Blazor.runtime.Module.FS.readFile(backupPath);
 
         const blob = new Blob([data], {
             type: 'application/octet-stream',
@@ -55,7 +55,7 @@ export async function synchronizeDbWithCache(file) {
 
         await db.cache.put(cachePath, response);
 
-        window.Module.FS.unlink(backupPath);
+        Blazor.runtime.Module.FS.unlink(backupPath);
 
         return 1;
     }
@@ -65,11 +65,11 @@ export async function synchronizeDbWithCache(file) {
 export async function generateDownloadLink(parent, file) {
 
     const backupPath = `${file}`;
-    const cachePath = `/data/cache/${file.substring(0, file.indexOf('_bak'))}`;
+    const cachePath = `/data/cache/${file}`;
     const db = window.sqlitedb;
     const resp = await db.cache.match(cachePath);
 
-    if (resp && resp.ok) {
+    if (resp?.ok) {
 
         const res = await resp.blob();
         if (res) {
@@ -100,7 +100,7 @@ export async function manualRestore(arrayBuffer, file) {
 
     if (arrayBuffer) {
         console.log(`Restoring ${arrayBuffer.byteLength} bytes.`);
-        window.Module.FS.writeFile(backupPath, new Uint8Array(arrayBuffer));
+        Blazor.runtime.Module.FS.writeFile(backupPath, new Uint8Array(arrayBuffer));
 
         const blob = new Blob([arrayBuffer], {
             type: 'application/octet-stream',

--- a/SqliteWasmTests/SqliteWasmTests.csproj
+++ b/SqliteWasmTests/SqliteWasmTests.csproj
@@ -1,20 +1,20 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/XmlDocGen/XmlDocGen.csproj
+++ b/XmlDocGen/XmlDocGen.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>


### PR DESCRIPTION
As noted here: https://github.com/aspnet/Announcements/issues/516
.NET 9 has some breaking changes for this library. This PR fixes those breaking changes primarily within browserCache.js.
This also includes other minor changes such as cleaning up the example by removing the dead links in the nav menu and fixing the BackupLink.razor component by getting the path for the link properly.

I updated all projects to target .NET 9 and updated all references.

This is a breaking change for .NET 8 and below projects.